### PR TITLE
Add analysis of users visiting SaB content

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -44,3 +44,6 @@ export DIR_SRC_UTILS=$(pwd)/src/utils
 
 # Add environment variables for the `tests` directory
 export DIR_TESTS=$(pwd)/tests
+
+import os
+GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/notebooks/start-a-business-checker/users_visiting_two_start_a_business_content_items.ipynb
+++ b/notebooks/start-a-business-checker/users_visiting_two_start_a_business_content_items.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Users visiting two start a business content items\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import google.auth\n",
+    "from google.cloud import bigquery\n",
+    "import os\n",
+    "from datetime import datetime, timedelta"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% code\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def create_big_query_client():\n",
+    "    credentials, project_id = google.auth.default()\n",
+    "    return bigquery.Client(credentials=credentials, project=project_id)\n",
+    "\n",
+    "def query():\n",
+    "    filepath = os.path.join(os.getenv(\"DIR_NOTEBOOKS\"), \"start-a-business-checker\", \"users_visiting_two_start_a_business_content_items.sql\")\n",
+    "    with open(filepath, 'r') as file:\n",
+    "        lines = \" \".join(line.strip(\"\\n\") for line in file)\n",
+    "    return lines\n",
+    "\n",
+    "def fetch_data(date_from, date_to, pages):\n",
+    "    query_config = bigquery.QueryJobConfig(\n",
+    "        query_parameters=[\n",
+    "            bigquery.ArrayQueryParameter(\"pages\", \"STRING\",  pages),\n",
+    "            bigquery.ScalarQueryParameter(\"date_from\", \"STRING\", date_from),\n",
+    "            bigquery.ScalarQueryParameter(\"date_to\", \"STRING\", date_to),\n",
+    "        ]\n",
+    "    )\n",
+    "    client = create_big_query_client()\n",
+    "    user_movement_df = client.query(query(), job_config=query_config).to_dataframe()\n",
+    "    return user_movement_df\n",
+    "\n",
+    "\n",
+    "date_from = (datetime.today() - timedelta(weeks=4)).strftime('%Y%m%d')\n",
+    "date_to = datetime.today().strftime('%Y%m%d')\n",
+    "\n",
+    "pages = [\"/corporation-tax\", \"/check-if-you-need-tax-return\", \"/licence-finder/\", \"/browse/business/sale-goods-services-data\", \"/cartels-price-fixing\", \"/data-protection-your-business\", \"/running-a-limited-company\", \"/browse/business/setting-up\", \"/running-a-limited-company/signs-stationery-and-promotional-material\", \"/managing-your-waste-an-overview\", \"/intellectual-property-an-overview\", \"/business-support-helpline\", \"/guidance/register-for-email-reminders-from-companies-house\", \"/vat-registration\", \"/vat-registration/when-to-register\", \"/get-ready-to-employ-someone\", \"/business-finance-support?business_stages%5B%5D=not-yet-trading\", \"/business-coronavirus-support-finder\", \"/browse/employing-people\", \"/run-business-from-home\", \"/renting-business-property-tenant-responsibilities\", \"/browse/business/premises-rates\", \"/running-a-limited-company/signs-stationery-and-promotional-material\", \"/browse/business/premises-rates\", \"/running-a-limited-company/signs-stationery-and-promotional-material\", \"/browse/business/premises-rates\", \"/import-goods-into-uk\", \"/export-goods\", \"/vat-businesses\", \"/vat-registration/when-to-register\", \"/get-ready-to-employ-someone\", \"/research-export-markets\"]\n",
+    "movement_data = fetch_data(date_from, date_to, pages)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(\"Following pages included\")\n",
+    "for page in pages:\n",
+    "    print(page)\n",
+    "print()\n",
+    "print(f\"starting from date: {date_from}\")\n",
+    "print(f\"end at date: {date_to}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "movement_data.head(n=20)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def print_info(movement):\n",
+    "    movement_data_2_or_more_pages = movement[movement['countOfDistinctPages'] >= 2]\n",
+    "    total_sessions_with_2_or_more_pages = movement_data_2_or_more_pages['numberOfSessions'].sum()\n",
+    "    four_weeks = total_sessions_with_2_or_more_pages\n",
+    "    one_week_average = four_weeks / 4\n",
+    "    print(f\"In 4 weeks, number of sessions that hit two or more pages in list: {str(four_weeks)}\")\n",
+    "    print(f\"In 1 week (average of 4 weeks), number of sessions that hit two or more pages in list: {str(one_week_average)}\")\n",
+    "\n",
+    "print_info(movement_data)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "extra_pages_from_spreadsheet = [\"/business-finance-support\", \"/make-court-claim-for-money\", \"/make-money-claim\", \"/respond-money-claim\", \"/business-coronavirus-support-finder\", \"/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme\", \"/apply-start-up-loan\", \"/write-business-plan\", \"/company-filing-software\", \"/correct-your-business-rates\", \"/send-rent-lease-details\", \"/planning-permission-england-wales\", \"/introduction-to-business-rates\", \"/calculate-your-business-rates\", \"/run-business-from-home\", \"/apply-for-business-rate-relief\", \"/find-government-property\", \"/contact-your-local-council-about-business-rates\", \"/energy-performance-certificate-commercial-property\", \"/workplace-fire-safety-your-responsibilities\", \"/find-an-energy-assessor\", \"/workplace-temperatures\", \"/renting-business-property-tenant-responsibilities\", \"/scaffolding-rules\", \"/can-i-use-cctv-at-my-commercial-premises\", \"/water-and-sewerage-rates-for-businesses\", \"/who-is-responsible-for-asbestos-found-in-my-commercial-property\", \"/non-domestic-renewable-heat-incentive\", \"/appeal-lawful-development-certificate-decision\", \"/get-rebate-refund-business-rates\", \"/get-your-air-conditioning-system-inspected\", \"/register-boat-coastguard-safety-scheme\", \"/renewing-your-commercial-property-lease\", \"/send-vat-return\", \"/pay-vat\", \"/use-construction-industry-scheme-online\", \"/pay-corporation-tax\", \"/vat-registration\", \"/file-your-company-accounts-and-tax-return\", \"/vat-returns\", \"/corporation-tax\", \"/pay-tax-direct-debit\", \"/pay-tax-debit-credit-card\", \"/prepare-file-annual-accounts-for-limited-company\", \"/capital-allowances\", \"/company-tax-returns\", \"/reclaim-vat\", \"/tell-hmrc-changed-business-details\", \"/corporation-tax-rates\", \"/what-you-must-do-as-a-cis-subcontractor\", \"/vat-businesses\", \"/what-you-must-do-as-a-cis-contractor\", \"/tax-buy-shares\", \"/work-out-capital-allowances\", \"/corporation-tax-accounting-period\", \"/first-company-accounts-and-return\", \"/vat-registration-thresholds\", \"/capital-gains-tax-businesses\", \"/dormant-company\", \"/tax-compliance-checks\", \"/capital-allowances-sell-asset\", \"/tax-when-your-company-sells-assets\", \"/tax-limited-company-gives-to-charity\", \"/pay-construction-industry-scheme-cis-late-filing-penalty\", \"/get-refund-interest-corporation-tax\", \"/marginal-relief-calculator\", \"/government/collections/venture-capital-schemes-hmrc-manuals\", \"/complain-ofsted-report\", \"/calculate-tax-on-company-cars\", \"/update-company-car-details\", \"/expenses-and-benefits-a-to-z\", \"/employer-reporting-expenses-benefits\", \"/expenses-and-benefits-trivial-benefits\", \"/expenses-and-benefits-loans-provided-to-employees\", \"/paye-settlement-agreements\", \"/wood-packaging-import-export\", \"/take-goods-sell-abroad\", \"/taking-goods-out-uk-temporarily\", \"/intrastat\", \"/research-export-markets\", \"/overseas-customers-export-opportunities\", \"/barriers-trading-investing-abroad\", \"/check-eori-number\", \"/check-duties-customs-exporting\", \"/export-customs-declaration\", \"/export-goods\", \"/eori\", \"/goods-sent-from-abroad\", \"/get-rules-tariffs-trade-with-uk\", \"/import-customs-declaration\", \"/vat-on-services-from-abroad\", \"/import-goods-into-uk\", \"/trade-tariff\", \"/licence-finder\", \"/intellectual-property-an-overview\", \"/copyright\", \"/using-somebody-elses-intellectual-property\", \"/creative-works-licence\", \"/how-to-register-a-trade-mark\", \"/search-for-trademark\", \"/check-trade-marks-journal\", \"/search-trade-mark-decisions\", \"/track-a-trade-mark\", \"/notice-to-oppose-trademark\", \"/renew-your-trade-mark\", \"/patent-your-invention\", \"/apply-for-a-patent\", \"/search-for-patent\", \"/check-the-patents-journal\", \"/file-documents-pending-patent\", \"/search-patent-decisions\", \"/change-or-update-your-patent\", \"/renew-patent\", \"/get-uncertified-electronic-copy-patent\", \"/request-uk-processing-of-international-patent-application\", \"/register-a-design\", \"/search-registered-design\", \"/check-the-design-journal\", \"/unregistered-designs\", \"/apply-register-design\", \"/renew-registered-design\", \"/defend-your-intellectual-property\", \"/update-or-surrender-trade-marks\", \"/renew-patent-trademark-registered-design\", \"/get-copies-of-intellectual-property-documents\", \"/update-or-cancel-your-registered-design\", \"/file-your-confirmation-statement-with-companies-house\", \"/file-changes-to-a-company-with-companies-house\", \"/limited-company-formation\", \"/file-your-company-annual-accounts\", \"/set-up-limited-company\", \"/strike-off-your-company-from-companies-register\", \"/running-a-limited-company\", \"/closing-a-limited-company\", \"/directors-loans\", \"/annual-accounts\", \"/search-the-register-of-disqualified-company-directors\", \"/audit-exemptions-for-private-limited-companies\", \"/change-your-companys-year-end\", \"/register-as-an-overseas-company\", \"/company-director-disqualification\", \"/appeal-a-penalty-for-filing-your-company-accounts-late\", \"/make-changes-to-your-limited-company\", \"/queens-awards-for-enterprise\", \"/object-to-a-limited-company-being-struck-off\", \"/set-up-property-management-company\", \"/restart-a-non-trading-or-dormant-company\", \"/cartels-price-fixing\", \"/file-accounts-in-the-uk-as-an-overseas-company\", \"/contracts-finder\", \"/accepting-returns-and-giving-refunds\", \"/online-and-distance-selling-for-businesses\", \"/find-tender\", \"/trading-hours-for-retailers-the-law\", \"/invoicing-and-taking-payment-from-customers\", \"/data-protection-register-notify-ico-personal-data\", \"/data-protection-your-business\", \"/tendering-for-public-sector-contracts\", \"/product-labelling-the-law\", \"/weights-measures-and-packaging-the-law\", \"/marketing-advertising-law\", \"/pedlars-certificate\", \"/doorstep-selling-regulations\", \"/check-when-businesses-pay-invoices\", \"/respond-data-protection-request\", \"/digital-marketplace\", \"/unfair-terms-in-sales-contracts\", \"/entertainment-and-modelling-agencies\", \"/uk-registered-deaths\", \"/stop-being-self-employed\", \"/business-asset-disposal-relief\", \"/company-voluntary-arrangements\", \"/selling-your-business-your-responsibilities\", \"/mergers-when-they-will-be-investigated\", \"/employers-liability-insurance\", \"/employment-agencies-and-businesses\", \"/growing-your-business\", \"/employing-staff\", \"/set-up-business\", \"/report-an-environmental-incident\", \"/hazardous-waste-disposal\", \"/managing-your-waste-an-overview\", \"/how-to-classify-different-types-of-waste\", \"/dispose-hazardous-waste\", \"/green-taxes-and-reliefs\", \"/use-van-fuel-tools\", \"/contaminated-land\", \"/preventing-air-pollution\", \"/packaging-waste-designer-responsibilities\"]\n",
+    "pages_with_extra_pages = pages + extra_pages_from_spreadsheet\n",
+    "print(f\"{len(extra_pages_from_spreadsheet)} more pages, new total of {len(pages_with_extra_pages)}\")\n",
+    "print(\"Following pages included\")\n",
+    "for page in pages_with_extra_pages:\n",
+    "    print(page)\n",
+    "print()\n",
+    "movement_data_with_extra_pages = fetch_data(date_from, date_to, pages_with_extra_pages)\n",
+    "print_info(movement_data_with_extra_pages)\n",
+    "movement_data_with_extra_pages.head()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "len(pages)\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/start-a-business-checker/users_visiting_two_start_a_business_content_items.sql
+++ b/notebooks/start-a-business-checker/users_visiting_two_start_a_business_content_items.sql
@@ -1,0 +1,24 @@
+WITH target_pages_sessions AS (
+    SELECT 
+        CONCAT(fullVisitorId, "-", CAST(visitId AS STRING)) AS sessionId,
+        hits.page.pagePath,
+    	FROM `govuk-bigquery-analytics.87773428.ga_sessions_*`, UNNEST(hits) AS hits
+        WHERE hits.type = 'PAGE' AND hits.page.pagePath in UNNEST(@pages) AND _TABLE_SUFFIX BETWEEN @date_from AND @date_to
+            
+),
+
+count_distinct_pages_per_session AS (
+    SELECT 
+        sessionid, 
+        COUNT(distinct pagepath) as countOfDistinctPages
+        FROM target_pages_sessions
+    GROUP BY sessionId
+
+)
+
+SELECT 
+    COUNT(Sessionid) AS numberOfSessions, 
+    countOfDistinctPages
+FROM count_distinct_pages_per_session
+GROUP BY countOfDistinctPages
+ORDER BY countOfDistinctPages


### PR DESCRIPTION
Analysis of how many users visit >=2 SaB content items
in the same session over a period

Trello: https://trello.com/c/MWqGUoAK/498-find-out-how-many-users-look-at-2-sab-pages-in-the-same-session

# Summary

In order to know if our simple rule for a prompt for users on SaB content will provide enough data for an A/B test (the rule being, go to >=2 SaB content items in a single session) we need to know how many people are doing that to understand whether it's enough traffic to get good statistical results.

# Checklists


### General checks

- [x] Code runs
- [x] Developments are **secure** and [**ethical**](https://www.gov.uk/government/publications/data-ethics-framework))
- [x] You have made proportionate checks that the code works correctly
- [x] Test suite passes
- [ ] Assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if necessary
- [ ] [Minimum usable documentation](http://agilemodeling.com/essays/documentLate.htm) written in the `docs` folder
